### PR TITLE
Add tests for intgemm refactor

### DIFF
--- a/tests/decoder/intgemm/test_intgemm_16bit_preprocessed.sh
+++ b/tests/decoder/intgemm/test_intgemm_16bit_preprocessed.sh
@@ -43,7 +43,7 @@ $MRT_MARIAN/marian-decoder \
     -m $prefix.$suffix.bin -v $MRT_MODELS/student-eten/{vocab.spm,vocab.spm} \
     -i newstest2018.src -o $prefix.out \
     -b 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
-    --shortlist $MRT_MODELS/student-eten/lex.s2t 50 50 --cpu-threads 1 --int16 \
+    --shortlist $MRT_MODELS/student-eten/lex.s2t 50 50 --cpu-threads 1 \
     --quiet-translation
 
 # Print current and expected BLEU for debugging

--- a/tests/decoder/intgemm/test_intgemm_8bit_preprocessed.sh
+++ b/tests/decoder/intgemm/test_intgemm_8bit_preprocessed.sh
@@ -43,7 +43,7 @@ $MRT_MARIAN/marian-decoder \
     -m $prefix.$suffix.bin -v $MRT_MODELS/student-eten/{vocab.spm,vocab.spm} \
     -i newstest2018.src -o $prefix.out \
     -b 1 --mini-batch 32 --maxi-batch 100 --maxi-batch-sort src -w 128 \
-    --shortlist $MRT_MODELS/student-eten/lex.s2t 50 50 --cpu-threads 1 --int8 \
+    --shortlist $MRT_MODELS/student-eten/lex.s2t 50 50 --cpu-threads 1 \
     --quiet-translation
 
 # Print current and expected BLEU for debugging


### PR DESCRIPTION
This updates https://github.com/marian-nmt/marian-regression-tests/pull/56 for changes proposed in https://github.com/marian-nmt/marian-dev/pull/762.

It seems packing a model on the fly is not supported there (options `--int8/--int16` are removed), so the following tests fail:

    test_intgemm_16bit.sh
    test_intgemm_8bit.sh

Also, I don't know yet how to combine it with fbgemm, and the option for shifted version is not exposed, so the following fails:

    test_fbgemm_packed8_intgemm_int8.sh
    test_fbgemm_packed8_intgemm_int8_shifted.sh
    test_intgemm_8bit_shifted.sh

The last two tests produce different outputs than the original https://github.com/marian-nmt/marian-dev/pull/595:

    test_intgemm_16bit_preprocessed.sh
    test_intgemm_8bit_preprocessed.sh

@XapaJIaMnu Could you check if the different outputs produced by the intgemm_refactor branch are expected and update other tests or temporarily turn them off? All tests work with intgemm_refactorized.

Also, we don't have tests with sse2/sse3 yet.