### PR TITLE
Rename CPU flag from MRT_MARIAN_USE_MKL to MRT_MARIAN_USE_CPU

### DIFF
--- a/run_mrt.sh
+++ b/run_mrt.sh
@@ -109,7 +109,7 @@ fi
 # Check Marian compilation settings
 export MRT_MARIAN_BUILD_TYPE=$(cat $MRT_ROOT/cmake.log        | grep  -i "CMAKE_BUILD_TYPE=" | cut -f2 -d=)
 export MRT_MARIAN_COMPILER=$(cat $MRT_ROOT/cmake.log          | grep  -i "CMAKE_CXX_COMPILER=" | cut -f2 -d=)
-export MRT_MARIAN_USE_MKL=$(cat $MRT_ROOT/cmake.log           | egrep -i "COMPILE_CPU=(true|on|1)" | cat)
+export MRT_MARIAN_USE_CPU=$(cat $MRT_ROOT/cmake.log           | egrep -i "COMPILE_CPU=(true|on|1)" | cat)
 export MRT_MARIAN_USE_CUDA=$(cat $MRT_ROOT/cmake.log          | egrep -i "COMPILE_CUDA=(true|on|1)" | cat)
 export MRT_MARIAN_USE_CUDNN=$(cat $MRT_ROOT/cmake.log         | egrep -i "USE_CUDNN=(true|on|1)" | cat)
 export MRT_MARIAN_USE_SENTENCEPIECE=$(cat $MRT_ROOT/cmake.log | egrep -i "USE_SENTENCEPIECE=(true|on|1)" | cat)
@@ -118,7 +118,7 @@ export MRT_MARIAN_USE_UNITTESTS=$(cat $MRT_ROOT/cmake.log     | egrep -i "COMPIL
 
 log "Build type: $MRT_MARIAN_BUILD_TYPE"
 log "Using compiler: $MRT_MARIAN_COMPILER"
-log "Using MKL: $MRT_MARIAN_USE_MKL"
+log "Using CPU: $MRT_MARIAN_USE_CPU"
 log "Using CUDNN: $MRT_MARIAN_USE_CUDNN"
 log "Using SentencePiece: $MRT_MARIAN_USE_SENTENCEPIECE"
 log "Using FBGEMM: $MRT_MARIAN_USE_FBGEMM"

--- a/tests/decoder/align/test_align_cpu.sh
+++ b/tests/decoder/align/test_align_cpu.sh
@@ -8,8 +8,8 @@
 # Exit on error
 set -e
 
-# Skip if no MKL found
-if [ ! $MRT_MARIAN_USE_MKL ]; then
+# Skip if no CPU found
+if [ ! $MRT_MARIAN_USE_CPU ]; then
     exit 100
 fi
 

--- a/tests/decoder/intgemm/_test_intgemm_16bit.sh
+++ b/tests/decoder/intgemm/_test_intgemm_16bit.sh
@@ -9,7 +9,7 @@
 set -e
 
 # Skip if requirements are not met
-if [ ! $MRT_MARIAN_USE_MKL ]; then
+if [ ! $MRT_MARIAN_USE_CPU ]; then
     echo "Marian is not compiled with CPU" 1>&2
     exit 100
 elif ! grep -q "avx" /proc/cpuinfo; then

--- a/tests/decoder/intgemm/_test_intgemm_8bit.sh
+++ b/tests/decoder/intgemm/_test_intgemm_8bit.sh
@@ -9,7 +9,7 @@
 set -e
 
 # Skip if requirements are not met
-if [ ! $MRT_MARIAN_USE_MKL ]; then
+if [ ! $MRT_MARIAN_USE_CPU ]; then
     echo "Marian is not compiled with CPU" 1>&2
     exit 100
 elif ! grep -q "avx" /proc/cpuinfo; then

--- a/tests/decoder/intgemm/_test_intgemm_8bit_shifted.sh
+++ b/tests/decoder/intgemm/_test_intgemm_8bit_shifted.sh
@@ -9,7 +9,7 @@
 set -e
 
 # Skip if requirements are not met
-if [ ! $MRT_MARIAN_USE_MKL ]; then
+if [ ! $MRT_MARIAN_USE_CPU ]; then
     echo "Marian is not compiled with CPU" 1>&2
     exit 100
 elif ! grep -q "avx" /proc/cpuinfo; then

--- a/tests/decoder/intgemm/test_intgemm_16bit.sh
+++ b/tests/decoder/intgemm/test_intgemm_16bit.sh
@@ -9,7 +9,7 @@
 set -e
 
 # Skip if requirements are not met
-if [ ! $MRT_MARIAN_USE_MKL ]; then
+if [ ! $MRT_MARIAN_USE_CPU ]; then
     echo "Marian is not compiled with CPU" 1>&2
     exit 100
 elif ! grep -q "avx" /proc/cpuinfo; then

--- a/tests/decoder/intgemm/test_intgemm_16bit_avx2.sh
+++ b/tests/decoder/intgemm/test_intgemm_16bit_avx2.sh
@@ -9,7 +9,7 @@
 set -e
 
 # Skip if requirements are not met
-if [ ! $MRT_MARIAN_USE_MKL ]; then
+if [ ! $MRT_MARIAN_USE_CPU ]; then
     echo "Marian is not compiled with CPU" 1>&2
     exit 100
 elif ! grep -q "avx2" /proc/cpuinfo; then

--- a/tests/decoder/intgemm/test_intgemm_16bit_sse2.sh
+++ b/tests/decoder/intgemm/test_intgemm_16bit_sse2.sh
@@ -9,7 +9,7 @@
 set -e
 
 # Skip if requirements are not met
-if [ ! $MRT_MARIAN_USE_MKL ]; then
+if [ ! $MRT_MARIAN_USE_CPU ]; then
     echo "Marian is not compiled with CPU" 1>&2
     exit 100
 elif ! grep -q "sse2" /proc/cpuinfo; then

--- a/tests/decoder/intgemm/test_intgemm_8bit.sh
+++ b/tests/decoder/intgemm/test_intgemm_8bit.sh
@@ -9,7 +9,7 @@
 set -e
 
 # Skip if requirements are not met
-if [ ! $MRT_MARIAN_USE_MKL ]; then
+if [ ! $MRT_MARIAN_USE_CPU ]; then
     echo "Marian is not compiled with CPU" 1>&2
     exit 100
 elif ! grep -q "avx" /proc/cpuinfo; then

--- a/tests/decoder/intgemm/test_intgemm_8bit_avx2.sh
+++ b/tests/decoder/intgemm/test_intgemm_8bit_avx2.sh
@@ -9,7 +9,7 @@
 set -e
 
 # Skip if requirements are not met
-if [ ! $MRT_MARIAN_USE_MKL ]; then
+if [ ! $MRT_MARIAN_USE_CPU ]; then
     echo "Marian is not compiled with CPU" 1>&2
     exit 100
 elif ! grep -q "avx2" /proc/cpuinfo; then

--- a/tests/decoder/intgemm/test_intgemm_8bit_ssse3.sh
+++ b/tests/decoder/intgemm/test_intgemm_8bit_ssse3.sh
@@ -9,7 +9,7 @@
 set -e
 
 # Skip if requirements are not met
-if [ ! $MRT_MARIAN_USE_MKL ]; then
+if [ ! $MRT_MARIAN_USE_CPU ]; then
     echo "Marian is not compiled with CPU" 1>&2
     exit 100
 elif ! grep -q "ssse3" /proc/cpuinfo; then

--- a/tests/decoder/wmt16/test_ende_cpu.sh
+++ b/tests/decoder/wmt16/test_ende_cpu.sh
@@ -8,8 +8,8 @@
 # Exit on error
 set -e
 
-# Skip if no MKL found
-if [ ! $MRT_MARIAN_USE_MKL ]; then
+# Skip if no CPU found
+if [ ! $MRT_MARIAN_USE_CPU ]; then
     exit 100
 fi
 

--- a/tests/models/transformer/test_hard_aligns_cpu.sh
+++ b/tests/models/transformer/test_hard_aligns_cpu.sh
@@ -8,8 +8,8 @@
 # Exit on error
 set -e
 
-# Skip if no MKL found
-if [ ! $MRT_MARIAN_USE_MKL ]; then
+# Skip if no CPU found
+if [ ! $MRT_MARIAN_USE_CPU ]; then
     exit 100
 fi
 

--- a/tests/models/wnmt18/test_student_small.sh
+++ b/tests/models/wnmt18/test_student_small.sh
@@ -8,8 +8,8 @@
 # Exit on error
 set -e
 
-# Skip if no MKL found
-if [ ! $MRT_MARIAN_USE_MKL ]; then
+# Skip if no CPU found
+if [ ! $MRT_MARIAN_USE_CPU ]; then
     exit 100
 fi
 

--- a/tests/models/wnmt18/test_student_small_aan.sh
+++ b/tests/models/wnmt18/test_student_small_aan.sh
@@ -8,8 +8,8 @@
 # Exit on error
 set -e
 
-# Skip if no MKL found
-if [ ! $MRT_MARIAN_USE_MKL ]; then
+# Skip if no CPU found
+if [ ! $MRT_MARIAN_USE_CPU ]; then
     exit 100
 fi
 

--- a/tests/models/wnmt18/test_student_small_aan_intgemm16.sh
+++ b/tests/models/wnmt18/test_student_small_aan_intgemm16.sh
@@ -8,8 +8,8 @@
 # Exit on error
 set -e
 
-# Skip if no MKL found
-if [ ! $MRT_MARIAN_USE_MKL ]; then
+# Skip if no CPU found
+if [ ! $MRT_MARIAN_USE_CPU ]; then
     exit 100
 fi
 

--- a/tests/models/wnmt18/test_student_small_aan_intgemm8.sh
+++ b/tests/models/wnmt18/test_student_small_aan_intgemm8.sh
@@ -8,8 +8,8 @@
 # Exit on error
 set -e
 
-# Skip if no MKL found
-if [ ! $MRT_MARIAN_USE_MKL ]; then
+# Skip if no CPU found
+if [ ! $MRT_MARIAN_USE_CPU ]; then
     exit 100
 fi
 

--- a/tests/scorer/scores/test_scores_cpu.sh
+++ b/tests/scorer/scores/test_scores_cpu.sh
@@ -8,8 +8,8 @@
 # Exit on error
 set -e
 
-# Skip if no MKL found
-if [ ! $MRT_MARIAN_USE_MKL ]; then
+# Skip if no CPU found
+if [ ! $MRT_MARIAN_USE_CPU ]; then
     exit 100
 fi
 

--- a/tests/server/test_ende_cpu.sh
+++ b/tests/server/test_ende_cpu.sh
@@ -8,8 +8,8 @@
 # Exit on error
 set -e
 
-# Skip if no MKL found
-if [ ! $MRT_MARIAN_USE_MKL ]; then
+# Skip if no CPU found
+if [ ! $MRT_MARIAN_USE_CPU ]; then
     exit 100
 fi
 

--- a/tests/training/restoring/multi-gpu/test_adam_sync_cpu.sh
+++ b/tests/training/restoring/multi-gpu/test_adam_sync_cpu.sh
@@ -8,8 +8,8 @@
 # Exit on error
 set -e
 
-# Skip if no MKL found
-if [ ! $MRT_MARIAN_USE_MKL ]; then
+# Skip if no CPU found
+if [ ! $MRT_MARIAN_USE_CPU ]; then
     exit 100
 fi
 


### PR DESCRIPTION
The flag used to inform tests whether Marian was compiled with CPU-support includes the suffix `MKL`. 

This PR replaces this suffix with `CPU` instead. 