### PR TITLE
Updating training/restoring/optimizer regression tests expected keys

### DIFF
--- a/tests/training/restoring/optimizer/adagrad.keys.expected
+++ b/tests/training/restoring/optimizer/adagrad.keys.expected
@@ -1,2 +1,3 @@
 adagrad_gt
 master_parameters
+Total number of parameters: 21735680

--- a/tests/training/restoring/optimizer/adam.keys.expected
+++ b/tests/training/restoring/optimizer/adam.keys.expected
@@ -2,3 +2,4 @@ adam_mt
 adam_vt
 adam_denoms
 master_parameters
+Total number of parameters: 32603522


### PR DESCRIPTION
Adding a new line to the `adagrad.keys.expected` and `adam.keys.expected` files with the number of parameters.
The marian-dev `model_info.py` script is being updated to also print the model's number of parameters.

E.g.
```
Total number of parameters: 32603522
```