### PR TITLE
Add regression tests for metrics via pymarian 

### DIFF
--- a/tests/pymarian/setup.sh
+++ b/tests/pymarian/setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+which pymarian-eval >& /dev/null || {
+    PYMARIAN_WHL=$(echo $MRT_MARIAN/pymarian-*.whl)
+    echo "Installing pymarian from $PYMARIAN_WHL"
+    if [[ -f $PYMARIAN_WHL ]]; then
+        python -m pip install --upgrade pip
+        python -m pip install $PYMARIAN_WHL
+    else
+        echo "No pymarian wheel found at $PYMARIAN_WHL" 1>&2
+        exit 1
+    fi
+}
+
+python -m pip install pytest
+
+MARIAN_ROOT=${MARIAN_ROOT:-$(dirname $MRT_MARIAN)}
+PYMARIAN_TESTS_DIR=$MARIAN_ROOT/src/python/tests/regression
+test -d $PYMARIAN_TESTS_DIR || {
+    echo "$PYMARIAN_TESTS_DIR not found" 1>&2
+    exit 1
+}

--- a/tests/pymarian/test_pymarian.sh
+++ b/tests/pymarian/test_pymarian.sh
@@ -1,0 +1,4 @@
+MARIAN_ROOT=${MARIAN_ROOT:-$(dirname $MRT_MARIAN)}
+PYMARIAN_TESTS_DIR=$MARIAN_ROOT/src/python/tests/regression
+test -d $PYMARIAN_TESTS_DIR || exit 1
+python -m pytest $PYMARIAN_TESTS_DIR


### PR DESCRIPTION
* This is attempt no. 2 for adding regression tests to metrics. we've closed/abandoned previous attempt at #92 
* pymarian takes care of downloading models --> the setup is minimal.
* pytest takes care execution and assertions, --> the code for diffs is also minimal  